### PR TITLE
Enlarge the input buffer

### DIFF
--- a/netFT_openConnection.m
+++ b/netFT_openConnection.m
@@ -4,6 +4,7 @@ function [ u ] = netFT_openConnection(  )
 netFT = '192.168.1.1';
 port = 49152;
 u = udp(netFT,port);
+u = InputBufferSize = 8192;
 fopen(u);
 end
 

--- a/netFT_openConnection.m
+++ b/netFT_openConnection.m
@@ -4,7 +4,7 @@ function [ u ] = netFT_openConnection(  )
 netFT = '192.168.1.1';
 port = 49152;
 u = udp(netFT,port);
-u = InputBufferSize = 8192;
+u.InputBufferSize = 8192;
 fopen(u);
 end
 


### PR DESCRIPTION
Even though the RDT buffer of the sensor is 1, the force data somehow queues in the network. Here the input buffer size of the UDP port in MATLAB is set to its maximum in order to receive as much data as possible. So then we can flush them all and then read the updated data. Otherwise the input buffer may be filled with outdated data in queue and we can't read the up-to-date force when we use the function netFT_getFreshData(). However, because the buffer size is limited, it is still possible that the data is outdated when the sensor samples in high frequency (higher than around 200Hz in my test).